### PR TITLE
Check EOF during parse of cheat.db files, fixes #9804

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -227,7 +227,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 					continue;
 				}
 			loop:;
-			} while (line.substr(0, 2) != "_S");
+			} while (fs.good() && line.substr(0, 2) != "_S");
 			finished = true;
 		}
 		if (finished == true)


### PR DESCRIPTION
The inner loop inequality test needs a matching EOF check to prevent an infinite loop.

Checking directly at the main getline works, too, but since there are several other possible reads, I thought I'd test them all in one go.